### PR TITLE
Implement server WebSocket events

### DIFF
--- a/server/src/socket/handlers.ts
+++ b/server/src/socket/handlers.ts
@@ -2,32 +2,19 @@ import { Server, Socket } from "socket.io";
 import { HandleJoinRoom } from "./handlers/handleJoinRoom";
 import { HandleStartQuiz } from "./handlers/handleStartQuiz";
 import { HandleStartQuestion } from "./handlers/handleStartQuestion";
+import { HandleBuzz } from "./handlers/handleBuzz";
+import { HandleReconnect } from "./handlers/handleReconnect";
+import { HandleDisconnect } from "./handlers/handleDisconnect";
 
 export const registerSocketHandlers = (io: Server) => {
   io.on("connection", (socket: Socket) => {
     console.log("クライアントに接続されました:", socket.id);
 
-    // TODO: ルーム参加処理
     HandleJoinRoom(io, socket);
-
-    // TODO: クイズ開始処理（全クライアントに startQuestion を送信）
     HandleStartQuiz(io, socket);
-
-    // TODO: 問題開始処理（全クライアントに startQuestion を送信）
     HandleStartQuestion(io, socket);
-
-    socket.on("buzz", () => {
-      console.log("バズが押されました:", socket.id);
-      // buzz 順管理
-    });
-
-    socket.on("disconnect", () => {
-      console.log("クライアントが切断されました:", socket.id);
-    });
-
-    socket.on("reconnect", (msg: string) => {
-      console.log("クライアントが再接続されました:", socket.id, msg);
-      // TODO: 再接続 状態復元処理
-    });
+    HandleBuzz(io, socket);
+    HandleReconnect(io, socket);
+    HandleDisconnect(io, socket);
   });
 };

--- a/server/src/socket/handlers/handleBuzz.ts
+++ b/server/src/socket/handlers/handleBuzz.ts
@@ -1,0 +1,37 @@
+import { Server, Socket } from "socket.io";
+import { BuzzResultPayload, ScoreUpdatePayload, StartQuestionPayload, QuizEndPayload } from "../types";
+import { roomManager } from "../roomManager";
+
+export const HandleBuzz = (io: Server, socket: Socket) => {
+  socket.on("buzz", () => {
+    const info = roomManager.findPlayerBySocket(socket.id);
+    if (!info) return;
+    const { roomId } = info;
+    const result = roomManager.buzz(roomId, socket.id);
+    if (!result) return;
+    if (result.first) {
+      io.to(roomId).emit("buzzResult", {
+        playerId: result.player.id,
+        playerName: result.player.name,
+      } as BuzzResultPayload);
+      roomManager.updateScore(roomId, result.player.id, 1);
+      const room = roomManager.getRoom(roomId);
+      if (room) {
+        io.to(roomId).emit("scoreUpdate", { players: room.players } as ScoreUpdatePayload);
+      }
+      const video = roomManager.nextQuestion(roomId);
+      if (!video) {
+        const finalScores = roomManager.endQuiz(roomId);
+        io.to(roomId).emit("quizEnd", { finalScores } as QuizEndPayload);
+        return;
+      }
+      const index = roomManager.getQuestionIndex(roomId);
+      const payload: StartQuestionPayload & { video: any; index: number } = {
+        roomId,
+        video,
+        index,
+      };
+      io.to(roomId).emit("startQuestion", payload);
+    }
+  });
+};

--- a/server/src/socket/handlers/handleDisconnect.ts
+++ b/server/src/socket/handlers/handleDisconnect.ts
@@ -1,0 +1,12 @@
+import { Server, Socket } from "socket.io";
+import { roomManager } from "../roomManager";
+
+export const HandleDisconnect = (io: Server, socket: Socket) => {
+  socket.on("disconnect", () => {
+    const result = roomManager.disconnectPlayer(socket.id);
+    if (result) {
+      io.to(result.roomId).emit("playerUpdate", result.room.players);
+    }
+    console.log("クライアントが切断されました:", socket.id);
+  });
+};

--- a/server/src/socket/handlers/handleJoinRoom.ts
+++ b/server/src/socket/handlers/handleJoinRoom.ts
@@ -1,43 +1,13 @@
 import { Server, Socket } from "socket.io";
-import { JoinRoomPayload, JoinSuccessPayload, Player, Room } from "../types";
-import { roomStore } from "../stores/roomStore";
+import { JoinRoomPayload, JoinSuccessPayload } from "../types";
+import { roomManager } from "../roomManager";
 
 export const HandleJoinRoom = (io: Server, socket: Socket) => {
   socket.on("joinRoom", (payload: JoinRoomPayload) => {
-    console.log(`ルームに参加しました: ${JSON.stringify(payload)}`);
-
     const { roomId, name, clientId } = payload;
-    const room = roomStore.get(roomId);
-
-    if (!room) {
-      socket.emit("joinRoomError", { message: "ルームが見つかりません" });
-      return;
-    }
-
-    // すでに同じ clientId のプレイヤーがいる場合（再接続対応）
-    let player = room.players.find((p) => p.clientId === clientId);
-
-    if (player) {
-      // 既存のプレイヤーが見つかった場合、再接続処理を行う
-      player.connected = true;
-      return;
-    } else {
-      player = {
-        id: socket.id,
-        name,
-        score: 0,
-        clientId,
-        connected: true,
-      };
-      room.players.push(player);
-    }
-
+    const { player, room } = roomManager.joinRoom(roomId, name, clientId, socket.id);
     socket.join(roomId);
-
-    const response: JoinSuccessPayload = {
-      player,
-      room,
-    };
+    const response: JoinSuccessPayload = { player, room };
     socket.emit("joinSuccess", response);
     io.to(roomId).emit("playerUpdate", room.players);
   });

--- a/server/src/socket/handlers/handleReconnect.ts
+++ b/server/src/socket/handlers/handleReconnect.ts
@@ -1,0 +1,17 @@
+import { Server, Socket } from "socket.io";
+import { ReconnectPayload } from "../types";
+import { roomManager } from "../roomManager";
+
+export const HandleReconnect = (io: Server, socket: Socket) => {
+  socket.on("reconnect", (payload: ReconnectPayload) => {
+    const { roomId, clientId } = payload;
+    const result = roomManager.reconnectPlayer(roomId, clientId, socket.id);
+    if (!result) {
+      socket.emit("reconnectError", { message: "再接続に失敗しました" });
+      return;
+    }
+    socket.join(roomId);
+    socket.emit("reconnectSuccess", { player: result.player, room: result.room });
+    io.to(roomId).emit("playerUpdate", result.room.players);
+  });
+};

--- a/server/src/socket/handlers/handleStartQuestion.ts
+++ b/server/src/socket/handlers/handleStartQuestion.ts
@@ -1,40 +1,22 @@
 import { Server, Socket } from "socket.io";
-import { StartQuestionPayload } from "../types";
-import { roomStore } from "../stores/roomStore";
-
-const currentQuestionIndex = new Map<string, number>();
+import { StartQuestionPayload, QuizEndPayload } from "../types";
+import { roomManager } from "../roomManager";
 
 export const HandleStartQuestion = (io: Server, socket: Socket) => {
   socket.on("startQuestion", (payload: StartQuestionPayload) => {
-    console.log(`問題開始リクエストを受信: ${JSON.stringify(payload)}`);
-
     const { roomId } = payload;
-    const room = roomStore.get(roomId);
-
-    if (!room) {
-      socket.emit("error", { message: "指定されたルームが存在しません。" });
-      return;
-    }
-
-    if (room.status !== "inProgress") {
-      socket.emit("error", { message: "クイズが進行中ではありません。" });
-      return;
-    }
-
-    const currentIndex = currentQuestionIndex.get(roomId) ?? 0;
-    const video = room.questions[currentIndex];
-
+    const video = roomManager.nextQuestion(roomId);
     if (!video) {
-      io.to(roomId).emit("quizEnd", { message: "問題が存在しません。" });
-      room.status = "finished";
-      roomStore.set(roomId, room);
+      const finalScores = roomManager.endQuiz(roomId);
+      io.to(roomId).emit("quizEnd", { finalScores } as QuizEndPayload);
       return;
     }
-
-    // 問題を全員に送信
-    io.to(roomId).emit("startQuestion", { currentIndex, video });
-
-    // 次のインデックスに進める
-    currentQuestionIndex.set(roomId, currentIndex + 1);
+    const index = roomManager.getQuestionIndex(roomId);
+    const data: StartQuestionPayload & { video: any; index: number } = {
+      roomId,
+      video,
+      index,
+    };
+    io.to(roomId).emit("startQuestion", data);
   });
 };

--- a/server/src/socket/handlers/handleStartQuiz.ts
+++ b/server/src/socket/handlers/handleStartQuiz.ts
@@ -1,35 +1,21 @@
 import { Server, Socket } from "socket.io";
-import { Room, StartQuizPayload } from "../types";
-import { roomStore } from "../stores/roomStore";
-import { HandleStartQuestion } from "./handleStartQuestion";
+import { StartQuizPayload, StartQuestionPayload } from "../types";
+import { roomManager } from "../roomManager";
 
 export const HandleStartQuiz = (io: Server, socket: Socket) => {
-	socket.on("startQuiz", (payload: StartQuizPayload) => {
-		console.log(`クイズ開始リクエストを受信: ${JSON.stringify(payload)}`);
-
-		const { roomId } = payload;
-		const room = roomStore.get(roomId);
-
-		if (!room) {
-			socket.emit("error", { message: "指定されたルームが存在しません。" });
-			return;
-		}
-		
-		if (room.status === "inProgress") {
-			socket.emit("error", { message: "クイズはすでに進行中です。" });
-			return;
-		}
-
-		if (room.status !== "waiting") {
-			socket.emit("error", { message: "クイズを開始できない状態です。" });
-			return;
-		}
-
-		// 状態を "inProgress" に変更
-		room.status = "inProgress";
-		roomStore.set(roomId, room);
-
-		// HandleStartQuestion() を呼び出して問題を開始
-		HandleStartQuestion(io, socket);
-	});
-}
+  socket.on("startQuiz", (payload: StartQuizPayload) => {
+    const { roomId } = payload;
+    const video = roomManager.startQuiz(roomId);
+    if (!video) {
+      socket.emit("error", { message: "クイズを開始できません" });
+      return;
+    }
+    const index = roomManager.getQuestionIndex(roomId);
+    const data: StartQuestionPayload & { video: any; index: number } = {
+      roomId,
+      video,
+      index,
+    };
+    io.to(roomId).emit("startQuestion", data);
+  });
+};

--- a/server/src/socket/roomManager.ts
+++ b/server/src/socket/roomManager.ts
@@ -1,0 +1,128 @@
+import { Player, Room, Video } from "./types";
+
+interface RoomState {
+  room: Room;
+  questionIndex: number;
+  buzzQueue: string[]; // store player socket ids in the order they buzzed
+}
+
+export class RoomManager {
+  private rooms = new Map<string, RoomState>();
+
+  /** Get existing room or create new one */
+  private getOrCreateRoom(roomId: string): RoomState {
+    let state = this.rooms.get(roomId);
+    if (!state) {
+      const room: Room = {
+        id: roomId,
+        playListUrl: "",
+        introDuration: 0,
+        questions: [],
+        players: [],
+        status: "waiting",
+        createdAt: new Date().toISOString(),
+      };
+      state = { room, questionIndex: 0, buzzQueue: [] };
+      this.rooms.set(roomId, state);
+    }
+    return state;
+  }
+
+  getRoom(roomId: string): Room | undefined {
+    return this.rooms.get(roomId)?.room;
+  }
+
+  joinRoom(roomId: string, name: string, clientId: string, socketId: string) {
+    const state = this.getOrCreateRoom(roomId);
+    let player = state.room.players.find((p) => p.clientId === clientId);
+
+    if (player) {
+      player.name = name;
+      player.id = socketId;
+      player.connected = true;
+    } else {
+      player = { id: socketId, name, score: 0, clientId, connected: true };
+      state.room.players.push(player);
+    }
+
+    return { player, room: state.room };
+  }
+
+  reconnectPlayer(roomId: string, clientId: string, socketId: string) {
+    const state = this.rooms.get(roomId);
+    if (!state) return null;
+    const player = state.room.players.find((p) => p.clientId === clientId);
+    if (!player) return null;
+    player.id = socketId;
+    player.connected = true;
+    return { player, room: state.room };
+  }
+
+  disconnectPlayer(socketId: string) {
+    for (const [roomId, state] of this.rooms.entries()) {
+      const player = state.room.players.find((p) => p.id === socketId);
+      if (player) {
+        player.connected = false;
+        return { roomId, room: state.room };
+      }
+    }
+    return null;
+  }
+
+  findPlayerBySocket(socketId: string) {
+    for (const [roomId, state] of this.rooms.entries()) {
+      const player = state.room.players.find((p) => p.id === socketId);
+      if (player) return { roomId, player };
+    }
+    return null;
+  }
+
+  startQuiz(roomId: string): Video | null {
+    const state = this.rooms.get(roomId);
+    if (!state) return null;
+    state.room.status = "inProgress";
+    state.questionIndex = 0;
+    state.buzzQueue = [];
+    return state.room.questions[state.questionIndex] || null;
+  }
+
+  nextQuestion(roomId: string): Video | null {
+    const state = this.rooms.get(roomId);
+    if (!state) return null;
+    state.questionIndex += 1;
+    state.buzzQueue = [];
+    return state.room.questions[state.questionIndex] || null;
+  }
+
+  getQuestionIndex(roomId: string): number {
+    const state = this.rooms.get(roomId);
+    return state ? state.questionIndex : 0;
+  }
+
+  buzz(roomId: string, socketId: string) {
+    const state = this.rooms.get(roomId);
+    if (!state) return null;
+    const player = state.room.players.find((p) => p.id === socketId);
+    if (!player) return null;
+    if (state.buzzQueue.includes(socketId)) return { player, first: false };
+    state.buzzQueue.push(socketId);
+    return { player, first: state.buzzQueue.length === 1 };
+  }
+
+  updateScore(roomId: string, playerId: string, delta: number) {
+    const state = this.rooms.get(roomId);
+    if (!state) return [] as Player[];
+    const player = state.room.players.find((p) => p.id === playerId);
+    if (player) player.score += delta;
+    return state.room.players;
+  }
+
+  endQuiz(roomId: string) {
+    const state = this.rooms.get(roomId);
+    if (!state) return [] as Player[];
+    state.room.status = "finished";
+    return [...state.room.players].sort((a, b) => b.score - a.score);
+  }
+}
+
+export const roomManager = new RoomManager();

--- a/server/src/socket/types.ts
+++ b/server/src/socket/types.ts
@@ -73,3 +73,8 @@ export interface ScoreUpdatePayload {
 export interface QuizEndPayload {
   finalScores: Player[];
 }
+// クライアント → サーバー：reconnect
+export interface ReconnectPayload {
+  roomId: string;
+  clientId: string;
+}


### PR DESCRIPTION
## Summary
- add RoomManager to manage rooms and players
- implement socket event handlers for join, quiz actions, buzzes, and reconnect
- update server to use new socket handlers

## Testing
- `npx tsc -p server/tsconfig.json --noEmit` *(fails: Cannot find module 'express')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6860586fbb588321a8386f7b0afdc1e4