### PR TITLE
Implement playlist fetching and WebSocket handlers

### DIFF
--- a/infra/lib/lambda/buzzHandler.py
+++ b/infra/lib/lambda/buzzHandler.py
@@ -1,2 +1,42 @@
+import json
+import os
+import boto3
+from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
+
+dynamodb = boto3.resource("dynamodb")
+player_table = dynamodb.Table(os.environ["PLAYER_TABLE"])
+
+
 def handler(event, context):
-	pass
+    connection_id = event["requestContext"]["connectionId"]
+    body = json.loads(event.get("body", "{}"))
+    elapsed = body.get("elapsed")
+
+    if elapsed is None:
+        return {"statusCode": 400, "body": "Missing elapsed"}
+
+    resp = player_table.query(
+        IndexName="connectionId-index",
+        KeyConditionExpression=Key("connectionId").eq(connection_id),
+    )
+    items = resp.get("Items", [])
+    if not items:
+        return {"statusCode": 404, "body": "Player not found"}
+
+    player = items[0]
+    key = {"roomId": player["roomId"], "playerId": player["playerId"]}
+
+    try:
+        player_table.update_item(
+            Key=key,
+            UpdateExpression="SET #el = :el",
+            ConditionExpression="attribute_not_exists(#el)",
+            ExpressionAttributeNames={"#el": "elapsed"},
+            ExpressionAttributeValues={":el": elapsed},
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "ConditionalCheckFailedException":
+            raise
+        # already recorded
+    return {"statusCode": 200, "body": ""}

--- a/infra/lib/lambda/fetchPlaylistHandler.py
+++ b/infra/lib/lambda/fetchPlaylistHandler.py
@@ -1,0 +1,39 @@
+import json
+import os
+import time
+import boto3
+from youtube_utils import fetch_valid_videos
+
+YOUTUBE_API_KEY = os.environ.get("YOUTUBE_API_KEY", "")
+
+dynamodb = boto3.resource("dynamodb")
+cache_table = dynamodb.Table(os.environ["PLAYLIST_CACHE_TABLE"])
+
+
+def handler(event, context):
+    body = json.loads(event.get("body", "{}"))
+    playlist_id = body.get("playlistId")
+    if not playlist_id:
+        return {"statusCode": 400, "body": "Missing playlistId"}
+
+    # Cache lookup
+    try:
+        resp = cache_table.get_item(Key={"playlistId": playlist_id})
+    except Exception:
+        resp = {}
+    item = resp.get("Item") if resp else None
+    if item and item.get("videos"):
+        return {"statusCode": 200, "body": json.dumps({"playlistId": playlist_id, "videos": item["videos"]})}
+
+    try:
+        videos = fetch_valid_videos(YOUTUBE_API_KEY, playlist_id)
+    except Exception:
+        return {"statusCode": 500, "body": "Failed to fetch playlist"}
+
+    expires_at = int(time.time()) + 600
+    try:
+        cache_table.put_item(Item={"playlistId": playlist_id, "videos": videos, "expiresAt": expires_at})
+    except Exception:
+        pass
+
+    return {"statusCode": 200, "body": json.dumps({"playlistId": playlist_id, "videos": videos})}

--- a/infra/lib/lambda/onDefault.py
+++ b/infra/lib/lambda/onDefault.py
@@ -1,2 +1,5 @@
 def handler(event, context):
-	pass
+    return {
+        "statusCode": 200,
+        "body": "Unrecognized route"
+    }

--- a/infra/lib/lambda/onDisconnect.py
+++ b/infra/lib/lambda/onDisconnect.py
@@ -1,2 +1,25 @@
+import os
+import boto3
+from boto3.dynamodb.conditions import Key
+
+dynamodb = boto3.resource("dynamodb")
+player_table = dynamodb.Table(os.environ["PLAYER_TABLE"])
+
+
 def handler(event, context):
-	pass
+    connection_id = event["requestContext"]["connectionId"]
+
+    resp = player_table.query(
+        IndexName="connectionId-index",
+        KeyConditionExpression=Key("connectionId").eq(connection_id),
+    )
+    items = resp.get("Items", [])
+    if not items:
+        return {"statusCode": 200, "body": "Player not found"}
+
+    item = items[0]
+    player_table.delete_item(
+        Key={"roomId": item["roomId"], "playerId": item["playerId"]}
+    )
+    # Future: update state instead of delete for reconnection support
+    return {"statusCode": 200, "body": "Disconnected"}

--- a/infra/lib/lambda/youtube_utils.py
+++ b/infra/lib/lambda/youtube_utils.py
@@ -1,0 +1,46 @@
+import json
+import urllib.parse
+import urllib.request
+from typing import List
+
+YOUTUBE_API_BASE = "https://www.googleapis.com/youtube/v3"
+
+
+def _get_json(url: str) -> dict:
+    with urllib.request.urlopen(url) as resp:
+        return json.loads(resp.read().decode())
+
+
+def fetch_playlist_items(api_key: str, playlist_id: str, max_results: int = 50) -> List[str]:
+    params = urllib.parse.urlencode({
+        "part": "contentDetails",
+        "playlistId": playlist_id,
+        "maxResults": max_results,
+        "key": api_key,
+    })
+    url = f"{YOUTUBE_API_BASE}/playlistItems?{params}"
+    data = _get_json(url)
+    return [item["contentDetails"]["videoId"] for item in data.get("items", [])]
+
+
+def filter_embeddable_videos(api_key: str, video_ids: List[str]) -> List[str]:
+    if not video_ids:
+        return []
+    params = urllib.parse.urlencode({
+        "part": "status",
+        "id": ",".join(video_ids),
+        "key": api_key,
+    })
+    url = f"{YOUTUBE_API_BASE}/videos?{params}"
+    data = _get_json(url)
+    valid: List[str] = []
+    for item in data.get("items", []):
+        status = item.get("status", {})
+        if status.get("embeddable") and status.get("privacyStatus") == "public":
+            valid.append(item.get("id"))
+    return valid
+
+
+def fetch_valid_videos(api_key: str, playlist_id: str) -> List[str]:
+    video_ids = fetch_playlist_items(api_key, playlist_id)
+    return filter_embeddable_videos(api_key, video_ids)


### PR DESCRIPTION
## Summary
- implement buzzHandler, onDisconnect, and onDefault lambdas
- add YouTube playlist fetching logic with caching
- create PlaylistCacheTable and connectionId GSI
- update CDK stack to wire new lambda and WebSocket route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686526abc2488321ac09ad474efb52dc