### PR TITLE
Implement WebSocket-based quiz pages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^6.30.1"
+        "react-router-dom": "^6.30.1",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1396,7 +1397,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1931,7 +1932,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3294,6 +3295,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^6.30.1",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,85 +1,20 @@
-import { useState } from 'react'
-import './App.css'
-import { connect, sendBuzz, sendJoinRoom, disconnect } from './hooks/useWebSocket'
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import TopPage from './pages/Top/TopPage';
+import RoomPage from './pages/Room/RoomPage';
+import ResultPage from './pages/Result/ResultPage';
+import './App.css';
 
-function App() {
-  const [count, setCount] = useState(0)
-  const [connected, setConnected] = useState(false)
-  const [messages, setMessages] = useState<string[]>([])
-  const [roomId, setRoomId] = useState('')
-  const [playerId, setPlayerId] = useState('')
-
-  const handleConnect = () => {
-    connect({
-      onOpen: () => setConnected(true),
-      onClose: () => setConnected(false),
-      onMessage: msg => setMessages(m => [...m, msg])
-    })
-  }
-
-  const handleDisconnect = () => {
-    disconnect()
-    setConnected(false)
-  }
-
-  const handleBuzz = () => {
-    sendBuzz(Date.now())
-  }
-
-  const handleJoinRoom = () => {
-    if (!roomId || !playerId) {
-      alert('roomIdとplayerIdを入力してください')
-      return
-    }
-    sendJoinRoom(roomId, playerId)
-  }
-
+const App: React.FC = () => {
   return (
-    <>
-      <h1>Vite + React + IntroQuiz</h1>
-      <div className="card">
-        <p>{connected ? '✅ Connected' : '❌ Disconnected'}</p>
-        <button onClick={handleConnect} disabled={connected}>Connect</button>
-        <button onClick={handleDisconnect} disabled={!connected}>Disconnect</button>
-        <button onClick={handleBuzz} disabled={!connected}>Send Buzz</button>
-        <button onClick={() => setCount(c => c + 1)}>count is {count}</button>
-      </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<TopPage />} />
+        <Route path="/room" element={<RoomPage />} />
+        <Route path="/result" element={<ResultPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
+};
 
-      <div className="card">
-        <h2>Join Room</h2>
-        <input
-          type="text"
-          placeholder="roomId"
-          value={roomId}
-          onChange={e => setRoomId(e.target.value)}
-          className="input"
-        />
-        <input
-          type="text"
-          placeholder="playerId"
-          value={playerId}
-          onChange={e => setPlayerId(e.target.value)}
-          className="input"
-        />
-        <button onClick={handleJoinRoom} disabled={!connected}>
-          Send JoinRoom
-        </button>
-      </div>
-
-      <div className="card">
-        <h2>Messages</h2>
-        <ul>
-          {messages.map((m, i) => (
-            <li key={i}>{m}</li>
-          ))}
-        </ul>
-      </div>
-
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
-}
-
-export default App
+export default App;

--- a/frontend/src/components/VideoPlayer.tsx
+++ b/frontend/src/components/VideoPlayer.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+
+interface Props {
+  videoId: string;
+  onStart: (timestamp: number) => void;
+}
+
+const VideoPlayer: React.FC<Props> = ({ videoId, onStart }) => {
+  const hasStartedRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasStartedRef.current) {
+      const ts = performance.now();
+      hasStartedRef.current = true;
+      onStart(ts);
+    }
+  }, [onStart]);
+
+  return (
+    <iframe
+      width="560"
+      height="315"
+      src={`https://www.youtube.com/embed/${videoId}?autoplay=1`}
+      title="YouTube video player"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+    />
+  );
+};
+
+export default VideoPlayer;

--- a/frontend/src/lib/parseYoutubeUrl.ts
+++ b/frontend/src/lib/parseYoutubeUrl.ts
@@ -1,0 +1,10 @@
+export const parseYoutubeUrl = (url: string): string | null => {
+  try {
+    const u = new URL(url);
+    const id = u.searchParams.get('list');
+    return id || null;
+  } catch {
+    const match = url.match(/[?&]list=([^&]+)/);
+    return match ? match[1] : null;
+  }
+};

--- a/frontend/src/pages/Result/ResultPage.tsx
+++ b/frontend/src/pages/Result/ResultPage.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 const ResultPage: React.FC = () => {
-	return (
-		<div>
-			<h1>Result Page</h1>
-		</div>
-	);
+  return (
+    <div>
+      <h1>Result Page</h1>
+    </div>
+  );
 };
 
 export default ResultPage;

--- a/frontend/src/pages/Room/RoomPage.tsx
+++ b/frontend/src/pages/Room/RoomPage.tsx
@@ -1,11 +1,73 @@
-import React from 'react';
+import { useEffect } from 'react';
+import { useWebSocket } from '../../hooks/useWebSocket';
+import { useQuizStore } from '../../stores/useQuizStore';
+import type { WSIncoming } from '../../types/websocket';
 
 const RoomPage: React.FC = () => {
-	return (
-		<div>
-			<h1>Room Page</h1>
-		</div>
-	);
+  const { send, messages } = useWebSocket();
+  const {
+    roomId,
+    playerId,
+    startTimestamp,
+    setRoomId,
+    setPlayerId,
+    setStartTimestamp,
+  } = useQuizStore();
+
+  useEffect(() => {
+    const last = messages[messages.length - 1] as WSIncoming | undefined;
+    if (!last) return;
+    if (
+      last.type === 'joinRoomAck' &&
+      typeof last.roomId === 'string' &&
+      typeof last.playerId === 'string'
+    ) {
+      setRoomId(last.roomId);
+      setPlayerId(last.playerId);
+    } else if (
+      last.type === 'quizStarted' &&
+      typeof last.startTimestamp === 'number'
+    ) {
+      setStartTimestamp(last.startTimestamp);
+    }
+  }, [messages, setPlayerId, setRoomId, setStartTimestamp]);
+
+  const handleJoin = () => {
+    if (!roomId || !playerId) return;
+    send({ action: 'joinRoom', roomId, playerId });
+  };
+
+  const handleStartQuiz = () => {
+    if (!roomId) return;
+    send({ action: 'startQuiz', roomId });
+  };
+
+  const handleBuzz = () => {
+    if (!startTimestamp) return;
+    const elapsed = performance.now() - startTimestamp;
+    send({ action: 'buzz', elapsed });
+  };
+
+  return (
+    <div>
+      <h1>Room Page</h1>
+      <input
+        type="text"
+        placeholder="roomId"
+        value={roomId}
+        onChange={(e) => setRoomId(e.target.value)}
+      />
+      <input
+        type="text"
+        placeholder="playerId"
+        value={playerId}
+        onChange={(e) => setPlayerId(e.target.value)}
+      />
+      <button onClick={handleJoin}>Join Room</button>
+      <button onClick={handleStartQuiz}>Start Quiz</button>
+      <button onClick={handleBuzz}>Buzz</button>
+    </div>
+  );
 };
 
 export default RoomPage;

--- a/frontend/src/pages/Top/TopPage.tsx
+++ b/frontend/src/pages/Top/TopPage.tsx
@@ -1,11 +1,55 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
+import { useWebSocket } from '../../hooks/useWebSocket';
+import { parseYoutubeUrl } from '../../lib/parseYoutubeUrl';
+import type { WSIncoming } from '../../types/websocket';
 
 const TopPage: React.FC = () => {
-	return (
-		<div>
-			<h1>Top Page</h1>
-		</div>
-	);
+  const { send, messages } = useWebSocket();
+  const [url, setUrl] = useState('');
+  const [playlistId, setPlaylistId] = useState<string>('');
+  const [videos, setVideos] = useState<string[]>([]);
+
+  useEffect(() => {
+    const last = messages[messages.length - 1] as WSIncoming | undefined;
+    if (!last) return;
+    if (
+      last.type === 'playlistFetched' &&
+      typeof last.playlistId === 'string' &&
+      Array.isArray(last.videos)
+    ) {
+      setPlaylistId(last.playlistId);
+      setVideos(last.videos);
+    }
+  }, [messages]);
+
+  const handleFetch = () => {
+    const id = parseYoutubeUrl(url);
+    if (!id) return;
+    send({ action: 'fetchPlaylist', playlistId: id });
+  };
+
+  return (
+    <div>
+      <h1>Top Page</h1>
+      <input
+        type="text"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        placeholder="YouTube Playlist URL"
+      />
+      <button onClick={handleFetch}>Fetch Playlist</button>
+      {playlistId && (
+        <div>
+          <h2>Playlist: {playlistId}</h2>
+          <ul>
+            {videos.map((v) => (
+              <li key={v}>{v}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default TopPage;

--- a/frontend/src/stores/useQuizStore.ts
+++ b/frontend/src/stores/useQuizStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+interface QuizState {
+  roomId: string;
+  playerId: string;
+  startTimestamp: number | null;
+  setRoomId: (id: string) => void;
+  setPlayerId: (id: string) => void;
+  setStartTimestamp: (ts: number | null) => void;
+}
+
+export const useQuizStore = create<QuizState>((set) => ({
+  roomId: '',
+  playerId: '',
+  startTimestamp: null,
+  setRoomId: (id) => set({ roomId: id }),
+  setPlayerId: (id) => set({ playerId: id }),
+  setStartTimestamp: (ts) => set({ startTimestamp: ts }),
+}));

--- a/frontend/src/types/websocket.ts
+++ b/frontend/src/types/websocket.ts
@@ -1,0 +1,11 @@
+export type WSOutgoing =
+  | { action: 'joinRoom'; roomId: string; playerId: string }
+  | { action: 'fetchPlaylist'; playlistId: string }
+  | { action: 'startQuiz'; roomId: string }
+  | { action: 'buzz'; elapsed: number };
+
+export type WSIncoming =
+  | { type: 'joinRoomAck'; roomId: string; playerId: string }
+  | { type: 'playlistFetched'; playlistId: string; videos: string[] }
+  | { type: 'quizStarted'; startTimestamp: number }
+  | { type: string; [key: string]: unknown };


### PR DESCRIPTION
## Summary
- set up routing for top, room and result pages
- use typed WebSocket hook with runtime guards
- manage playlist and room data via hooks and Zustand
- add zustand dependency

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686530f23c048321a46d145db490c8ae