### PR TITLE
Add WS_ENDPOINT environment variable

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -68,6 +68,8 @@ export class InfraStack extends Stack {
         PLAYER_TABLE: playerTable.tableName,
         PLAYLIST_CACHE_TABLE: playlistCacheTable.tableName,
         YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY ?? "",
+        // WebSocket API endpoint will be injected after the API is created
+        WS_ENDPOINT: "",
       },
     };
 
@@ -143,6 +145,11 @@ export class InfraStack extends Stack {
           })
         ),
       },
+    });
+
+    // Inject the WebSocket endpoint into each Lambda environment
+    [onConnect, onDisconnect, onDefault].forEach((fn) => {
+      fn.addEnvironment("WS_ENDPOINT", webSocketApi.apiEndpoint);
     });
   }
 }


### PR DESCRIPTION
## Summary
- add placeholder for WebSocket endpoint in lambda environment
- inject `WS_ENDPOINT` after WebSocket API creation
- run build and attempt deployment

## Testing
- `npm run build`
- `npm test`
- `cdk deploy` *(fails: Unable to resolve AWS account)*

------
https://chatgpt.com/codex/tasks/task_e_686bdecd67c88321b34fb4a532f6dda1