### PR TITLE
Fix missing json import in onDisconnect lambda

### DIFF
--- a/infra/lib/lambda/onDisconnect.py
+++ b/infra/lib/lambda/onDisconnect.py
@@ -1,5 +1,6 @@
 import os
 import boto3
+import json
 from boto3.dynamodb.conditions import Key
 
 dynamodb = boto3.resource("dynamodb")


### PR DESCRIPTION
## Summary
- import `json` in `onDisconnect` for proper `json.dumps` usage

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686bdecf0bcc8321ac089902d8a37734