### PR TITLE
Implement playerId generation

### DIFF
--- a/frontend/src/pages/Top/TopPage.tsx
+++ b/frontend/src/pages/Top/TopPage.tsx
@@ -6,6 +6,8 @@ const TopPage: React.FC = () => {
   const { send, messages } = useWebSocket();
   const [roomId, setRoomId] = useState('');
   const [playerName, setPlayerName] = useState('');
+  // Generate a playerId only once when the component mounts
+  const [playerId] = useState(() => crypto.randomUUID());
   const [error, setError] = useState('');
   const navigate = useNavigate();
 
@@ -16,8 +18,8 @@ const TopPage: React.FC = () => {
       setError('Room IDとプレイヤー名を入力してください');
       return;
     }
-    send({ action: 'joinRoom', roomId, playerName });
-  }, [roomId, playerName, send]);
+    send({ action: 'joinRoom', roomId, playerName, playerId });
+  }, [roomId, playerName, playerId, send]);
 
   // メッセージ監視
   useEffect(() => {

--- a/infra/lib/lambda/handlers/joinRoom.py
+++ b/infra/lib/lambda/handlers/joinRoom.py
@@ -1,6 +1,7 @@
 import os
 import boto3
 import json
+import uuid
 from boto3.dynamodb.conditions import Key
 
 dynamodb = boto3.resource('dynamodb')
@@ -11,7 +12,7 @@ def handler(event, context):
     body = event.get('body')
     data = json.loads(body) if isinstance(body, str) else body
     room_id = data.get('roomId')
-    player_id = data.get('playerId')
+    player_id = data.get('playerId') or str(uuid.uuid4())
     player_name = data.get('playerName')
     connection_id = event['requestContext']['connectionId']
 


### PR DESCRIPTION
## Summary
- generate a playerId on the client when entering a room
- create a fallback UUID in the `joinRoom` handler when none is supplied

## Testing
- `npm run lint` in `frontend`
- `python -m py_compile joinRoom.py`

------
https://chatgpt.com/codex/tasks/task_e_686bded0a5ec8321ba445fd6a36fa853