### PR TITLE
Fix mismatched quiz start event

### DIFF
--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 export type WSMessage =
   | { type: 'joinRoomAck'; roomId: string; playerId: string }
   | { type: 'playlistFetched'; playlistId: string; videos: string[] }
-  | { type: 'quizStarted'; startTimestamp: number }
+  | { type: 'startQuiz'; videoId: string; questionIndex: number }
   | { type: string; [key: string]: unknown };
 
 export type WebSocketState = {

--- a/frontend/src/pages/Room/RoomPage.tsx
+++ b/frontend/src/pages/Room/RoomPage.tsx
@@ -27,7 +27,7 @@ const RoomPage: React.FC = () => {
       case 'playerListUpdate':
         if ('players' in last && Array.isArray(last.players)) setPlayers(last.players);
         break;
-      case 'quizStarted':
+      case 'startQuiz':
         if ('videoId' in last && typeof last.videoId === 'string') setVideoId(last.videoId);
         setIsQuizActive(true);
         setIsBuzzAccepted(false);

--- a/frontend/src/types/websocket.ts
+++ b/frontend/src/types/websocket.ts
@@ -7,7 +7,7 @@ export type WSOutgoing =
 export type WSIncoming =
   | { type: 'joinRoomAck'; roomId: string; playerId: string }
   | { type: 'playlistFetched'; playlistId: string; videos: string[] }
-  | { type: 'quizStarted'; startTimestamp: number; videoId: string }
+  | { type: 'startQuiz'; videoId: string; questionIndex: number }
   | { type: 'playerListUpdate'; players: string[] }
   | { type: 'buzzAccepted' }
   | { type: 'buzzResult' }


### PR DESCRIPTION
## Summary
- align WebSocket event names between backend and frontend
- update event types accordingly

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686bded1f8d88321a10537528ff77e1d