### PR TITLE
fix: align answer result fields

### DIFF
--- a/frontend/src/pages/Room/RoomPage.tsx
+++ b/frontend/src/pages/Room/RoomPage.tsx
@@ -62,9 +62,12 @@ const RoomPage: React.FC = () => {
         break;
       case "answerResult":
         setAnswerResult({
-          correct: "correct" in last ? !!last.correct : false,
+          correct:
+            "result" in last && last.result === "correct" ? true : false,
           title:
-            "title" in last && typeof last.title === "string" ? last.title : "",
+            "videoTitle" in last && typeof last.videoTitle === "string"
+              ? last.videoTitle
+              : "",
         });
         setIsBuzzAccepted(false);
         setInfo("");

--- a/frontend/src/types/websocket.ts
+++ b/frontend/src/types/websocket.ts
@@ -21,7 +21,11 @@ export type WSIncoming =
   | { type: "startQuiz"; videoId: string; questionIndex: number }
   | { type: "buzzAccepted" }
   | { type: "buzzResult" }
-  | { type: "answerResult"; correct: boolean; title: string }
+  | {
+      type: "answerResult";
+      result: "correct" | "incorrect";
+      videoTitle: string;
+    }
   | { type: "quizEnded"; rankings: Ranking[] } // ← ここを追加
   | { type: "roomInfo"; roomName: string; players: string[] }
   | { type: string; [key: string]: unknown };


### PR DESCRIPTION
## Summary
- match field names between backend and frontend
- update `WSIncoming` type

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: missing modules)*
- `npm test` in `infra` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_686c5706c93c8321909dc973e82ac1fa