### PR TITLE
Update buzz and answer message handling

### DIFF
--- a/frontend/src/pages/Room/RoomPage.tsx
+++ b/frontend/src/pages/Room/RoomPage.tsx
@@ -1,13 +1,19 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useWebSocket } from "../../hooks/useWebSocket";
 import { useNavigate } from "react-router-dom";
+import { useRoomStore } from "../../stores/useRoomStore";
+import { usePlayerStore } from "../../stores/usePlayerStore";
 
 const RoomPage: React.FC = () => {
   const { send, messages } = useWebSocket();
   const navigate = useNavigate();
+  const roomId = useRoomStore((state) => state.roomId);
+  const playerId = usePlayerStore((state) => state.playerId);
   const [roomName, setRoomName] = useState("");
   const [players, setPlayers] = useState<string[]>([]);
   const [videoId, setVideoId] = useState("");
+  const [questionIndex, setQuestionIndex] = useState(0);
+  const [startTimestamp, setStartTimestamp] = useState<number | null>(null);
   const [isQuizActive, setIsQuizActive] = useState(false);
   const [isBuzzAccepted, setIsBuzzAccepted] = useState(false);
   const [isBuzzing, setIsBuzzing] = useState(false);
@@ -43,6 +49,12 @@ const RoomPage: React.FC = () => {
       case "startQuiz":
         if ("videoId" in last && typeof last.videoId === "string")
           setVideoId(last.videoId);
+        if ("questionIndex" in last && typeof last.questionIndex === "number") {
+          setQuestionIndex(last.questionIndex);
+        } else {
+          setQuestionIndex(0);
+        }
+        setStartTimestamp(Date.now());
         setIsQuizActive(true);
         setIsBuzzAccepted(false);
         setIsBuzzing(false);
@@ -80,15 +92,28 @@ const RoomPage: React.FC = () => {
   // 早押し
   const handleBuzz = useCallback(() => {
     setIsBuzzing(true);
-    send({ action: "buzz" });
-  }, [send]);
+    const elapsed = startTimestamp ? Date.now() - startTimestamp : 0;
+    send({
+      action: "buzz",
+      roomId,
+      playerId,
+      elapsed,
+      questionIndex,
+    });
+  }, [send, startTimestamp, roomId, playerId, questionIndex]);
 
   // 解答送信
   const handleSendAnswer = useCallback(() => {
     if (!answer) return;
-    send({ action: "answer", answer });
+    send({
+      action: "answer",
+      roomId,
+      playerId,
+      answer,
+      questionIndex,
+    });
     setAnswer("");
-  }, [answer, send]);
+  }, [answer, send, roomId, playerId, questionIndex]);
 
   return (
     <div

--- a/frontend/src/pages/Top/TopPage.tsx
+++ b/frontend/src/pages/Top/TopPage.tsx
@@ -1,6 +1,8 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useWebSocket } from '../../hooks/useWebSocket';
 import { useNavigate } from 'react-router-dom';
+import { useRoomStore } from '../../stores/useRoomStore';
+import { usePlayerStore } from '../../stores/usePlayerStore';
 
 const TopPage: React.FC = () => {
   const { send, messages } = useWebSocket();
@@ -10,6 +12,8 @@ const TopPage: React.FC = () => {
   const [playerId] = useState(() => crypto.randomUUID());
   const [error, setError] = useState('');
   const navigate = useNavigate();
+  const setRoomIdStore = useRoomStore((state) => state.setRoomId);
+  const setPlayerIdStore = usePlayerStore((state) => state.setPlayerId);
 
   // joinRoomResultやerrorを監視
   const handleJoin = useCallback(() => {
@@ -18,8 +22,10 @@ const TopPage: React.FC = () => {
       setError('Room IDとプレイヤー名を入力してください');
       return;
     }
+    setRoomIdStore(roomId);
+    setPlayerIdStore(playerId);
     send({ action: 'joinRoom', roomId, playerName, playerId });
-  }, [roomId, playerName, playerId, send]);
+  }, [roomId, playerName, playerId, send, setRoomIdStore, setPlayerIdStore]);
 
   // メッセージ監視
   useEffect(() => {

--- a/frontend/src/types/websocket.ts
+++ b/frontend/src/types/websocket.ts
@@ -3,8 +3,20 @@ export type WSOutgoing =
   | { action: "createRoom"; roomId: string; roomName: string }
   | { action: "setPlaylist"; roomId: string; playlistUrl: string }
   | { action: "startQuiz"; roomId: string }
-  | { action: "buzz" /* もし elapsed を送るなら elapsed: number */ }
-  | { action: "answer"; answer: string }
+  | {
+      action: "buzz";
+      roomId: string;
+      playerId: string;
+      elapsed: number;
+      questionIndex: number;
+    }
+  | {
+      action: "answer";
+      roomId: string;
+      playerId: string;
+      answer: string;
+      questionIndex: number;
+    }
   | { action: "endQuiz"; roomId: string }
   | { action: string; [key: string]: unknown };
 


### PR DESCRIPTION
## Summary
- include roomId, playerId, elapsed and questionIndex when buzzing
- include roomId, playerId and questionIndex when answering
- persist room/player IDs in zustand store
- update WSOutgoing definitions

## Testing
- `npm run lint`
- `npm run build`
- `npx -y tsc -p frontend`


------
https://chatgpt.com/codex/tasks/task_e_686c56f776e4832199fa16db58915287